### PR TITLE
allow PyYAML dependency up to 6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ PACKAGES = ['googleads']
 
 DEPENDENCIES = ['google-auth>=1.0.0,<2.0.0',
                 'google-auth-oauthlib>=0.0.1,<1.0.0', 'pytz>=2015.7',
-                'PyYAML>=5.1, <6.0', 'requests>=2.0.0,<3.0.0',
+                'PyYAML>=6.0, <7.0', 'requests>=2.0.0,<3.0.0',
                 'xmltodict>=0.9.2,<1.0.0', 'zeep>=2.5.0']
 
 # Note: Breaking change introduced in pyfakefs 3.3.


### PR DESCRIPTION
PR Regarding issues  [510] (https://github.com/googleads/googleads-python-lib/issues/510) 
i.e.  googleads doesnt have support for latest pyyaml version but that is widely used in GCP composer version `composer-2.0.28-airflow-2.3.3` 
`failed to install pypi packages. googleads has requirement pyyaml <6.0, >=5.1, but you have pyyaml 6.0`


